### PR TITLE
Fixes broken documentation links

### DIFF
--- a/modules/homepage/public/views/partials/item.liquid
+++ b/modules/homepage/public/views/partials/item.liquid
@@ -3,11 +3,13 @@
     <a href="/{{ item.slug }}">{{ item.metadata.description }}</a>
   </td>
   <td>
+    {% if item.metadata.docs_slug != blank %}
     <a href="https://documentation.platformos.com/{{ item.metadata.docs_slug }}" target="_blank" rel="noopener">
       Open
       <sup>
         <img src="{{ 'modules/homepage/external.svg' | asset_url }}" width="12">
       </sup>
     </a>
+    {% endif %}
   </td>
 </tr>

--- a/modules/multilanguage/public/views/pages/multilanguage.liquid
+++ b/modules/multilanguage/public/views/pages/multilanguage.liquid
@@ -3,7 +3,7 @@ slug: multilanguage
 layout_name: application
 metadata:
   description: Example usage of translations to create multilanguage page
-  docs_slug: tutorials/translations/multilanguage-pages
+  docs_slug: tutorials/translations/multilanguage-page
 ---
 
 <h2 data-result="1">{{ 'modules/multilanguage/general.greeting' | t }}</h2>

--- a/modules/n_plus_one/public/views/pages/companies/index.liquid
+++ b/modules/n_plus_one/public/views/pages/companies/index.liquid
@@ -4,7 +4,7 @@ layout_name: application
 metadata:
   full_width: true
   description: Loading related models while avoiding n+1 queries. Increase speed 10x
-  docs_slug: tutorials/custom-model-types/loading-related-models
+  docs_slug: tutorials/model-schemas/loading-related-models
 ---
 {% include 'modules/n_plus_one/menu' %}
 

--- a/modules/n_plus_one/public/views/pages/programmers/with_companies_2.liquid
+++ b/modules/n_plus_one/public/views/pages/programmers/with_companies_2.liquid
@@ -4,7 +4,7 @@ layout_name: application
 metadata:
   full_width: true
   description: Measuring execution time of liquid code fragments (time_diff)
-  docs_slug: tutorials/performance/measuring-execution-time-liquid-time-diff
+  docs_slug: best-practices/performance/measuring-execution-time-liquid-time-diff
 ---
 {% include 'modules/n_plus_one/menu' %}
 


### PR DESCRIPTION
I checked all links to documentation topics on the examples site, and fixed the ones that didn't work. 

I also found 3 documentation links where there is now documentation (yet), I think the "Open" link in the Docs column could be removed for these lines:

- Example of generating PDF from html
- Payment Examples/Saving Account 
- Payment Examples/Saving Customer with Credit Card

Fixes https://github.com/mdyd-dev/nearme-documentation/issues/674